### PR TITLE
Use custom Docker image for repo2docker

### DIFF
--- a/R/create_containers.R
+++ b/R/create_containers.R
@@ -40,9 +40,9 @@ create_container_from_repo <- function(contribution_row) {
   if (nrow(matching_images) == 0) {
     repo2docker_call_template <- "repo2docker \\
     --no-run \\
+    --Repo2Docker.base_image=gesiscss/repo2docker_base_image_with_quarto \\
     --user-name methodshub \\
     --image-name ${image_name} \\
-    --appendix 'RUN conda install -y -n notebook --channel conda-forge quarto' \\
     ${git_repo_url}"
 
     repo2docker_call <- stringr::str_interp(


### PR DESCRIPTION
This is to help us to have better control of which version of Quarto we are installing

Closes https://github.com/GESIS-Methods-Hub/methodshub/issues/131